### PR TITLE
Use distribution code name for Debian/Ubuntu repositories

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -10,7 +10,7 @@ class zabbix::repo::debian {
 
   apt::source { 'zabbix':
     location   => "http://repo.zabbix.com/zabbix/${::zabbix::repo::version}/debian/",
-    release    => 'wheezy',
+    release    => $::lsbdistcodename,
     repos      => 'main',
     key        => '79EA5ED4',
     key_source => 'http://repo.zabbix.com/zabbix-official-repo.key',

--- a/manifests/repo/ubuntu.pp
+++ b/manifests/repo/ubuntu.pp
@@ -10,7 +10,7 @@ class zabbix::repo::ubuntu {
 
   apt::source { 'zabbix':
     location   => "http://repo.zabbix.com/zabbix/${::zabbix::repo::version}/ubuntu/",
-    release    => 'precise',
+    release    => $::lsbdistcodename,
     repos      => 'main',
     key        => '79EA5ED4',
     key_source => 'http://repo.zabbix.com/zabbix-official-repo.key',


### PR DESCRIPTION
Use distribution key name for Debian/Ubuntu repositories