### PR TITLE
Add fingerprints to APT keys

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -12,7 +12,7 @@ class zabbix::repo::debian {
     location   => "http://repo.zabbix.com/zabbix/${::zabbix::repo::version}/debian/",
     release    => $::lsbdistcodename,
     repos      => 'main',
-    key        => '79EA5ED4',
+    key        => 'FBABD5FB20255ECAB22EE194D13D58E479EA5ED4',
     key_source => 'http://repo.zabbix.com/zabbix-official-repo.key',
     pin        => $::zabbix::repo::apt_pin,
   }

--- a/manifests/repo/ubuntu.pp
+++ b/manifests/repo/ubuntu.pp
@@ -12,7 +12,7 @@ class zabbix::repo::ubuntu {
     location   => "http://repo.zabbix.com/zabbix/${::zabbix::repo::version}/ubuntu/",
     release    => $::lsbdistcodename,
     repos      => 'main',
-    key        => '79EA5ED4',
+    key        => 'FBABD5FB20255ECAB22EE194D13D58E479EA5ED4',
     key_source => 'http://repo.zabbix.com/zabbix-official-repo.key',
     pin        => $::zabbix::repo::apt_pin,
   }


### PR DESCRIPTION
Minor change. The Puppetlabs APT module (>=1.8.0) requires a full fingerprint on keys. Otherwise annoying warnings are now printed.